### PR TITLE
fix - unexpected string at the end of docerfile

### DIFF
--- a/generators/app/templates/Dockerfile
+++ b/generators/app/templates/Dockerfile
@@ -13,4 +13,4 @@ ADD app /app/
 RUN cd /app && npm run build
 
 #Default command
-CMD ["/app/runserver.sh"]FROM mhart/alpine-node:4.4
+CMD ["/app/runserver.sh"]


### PR DESCRIPTION
Removed `FROM mhart/alpine-node:4.4` from the end of the file, i guess its a typo.